### PR TITLE
Make `cog_default` optional in collection stac

### DIFF
--- a/api/src/schemas.py
+++ b/api/src/schemas.py
@@ -64,11 +64,6 @@ class DashboardCollection(Collection):
     class Config:
         allow_population_by_field_name = True
 
-    @validator("item_assets")
-    def cog_default_exists(cls, item_assets):
-        validators.cog_default_exists(item_assets)
-        return item_assets
-
     @root_validator
     def check_time_density(cls, values):
         validators.time_density_is_valid(values["is_periodic"], values["time_density"])

--- a/api/src/validators.py
+++ b/api/src/validators.py
@@ -78,16 +78,6 @@ def url_is_accessible(href: str):
         )
 
 
-def cog_default_exists(item_assets: Dict):
-    """
-    Ensures `cog_default` key exists in item_assets in a collection
-    """
-    try:
-        item_assets["cog_default"]
-    except KeyError:
-        raise ValueError("Collection doesn't have a default cog placeholder")
-
-
 def time_density_is_valid(is_periodic: bool, time_density: Union[str, None]):
     """
     Ensures that the time_density is valid based on the value of is_periodic


### PR DESCRIPTION
# Description
Not all valid STAC collection have `cog_default` key.
This lets the STAC catalog accept a collection without a `cog_default` asset.