### PR TITLE
update subnet type of lambda

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -210,7 +210,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_NAT
             ),
             allow_public_subnet=True,
             memory_size=2048,


### PR DESCRIPTION
adjust lambda subnet type to PRIVATE_WITH_NAT in lieu of PRIVATE_ISOLATED to resolve RuntimeError: There are no 'Isolated' subnet groups in this VPC. Available types: Private,Public