### PR TITLE
update lambda subnet type to PRIVATE_WITH_EGRESS

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -210,7 +210,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_WITH_NAT
+                else ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             allow_public_subnet=True,
             memory_size=2048,
@@ -285,7 +285,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             allow_public_subnet=True,
             memory_size=2048,


### PR DESCRIPTION
update lambda subnet type to PRIVATE_WITH_EGRESS to ensure functionality in SMCE and MCP environments